### PR TITLE
Add detailed age and lifespan calculations

### DIFF
--- a/BillionSecond/Program.cs
+++ b/BillionSecond/Program.cs
@@ -1,5 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
+using System;
+using System.Threading;
 
 namespace BillionSecond
 {
@@ -7,66 +7,102 @@ namespace BillionSecond
     {
         static void Main(string[] args)
         {
-            int birthYear;
-            int birthMonth;
-            int birthDay;
+            DateTime birthDate = ReadBirthDate();
+            DateTime now = DateTime.Now;
+            TimeSpan age = now.Subtract(birthDate);
 
-            birthYear = 1988;
-            birthMonth = 6;
-            birthDay = 24;
-
-           /* Console.WriteLine("Please enter your birth year:");
-            int.TryParse(Console.ReadLine(), out birthYear);
-            Console.WriteLine("Please enter your birth month:");
-            int.TryParse(Console.ReadLine(), out birthMonth);
-            Console.WriteLine("Please enter day of month:");
-            int.TryParse(Console.ReadLine(), out birthDay);*/
-
-
-            DateTime bd = new DateTime(birthYear, birthMonth, birthDay, 0, 0, 0);
-            DateTime billSec = bd.AddSeconds(1000000000);
-
-
-            TimeSpan span = DateTime.Now.Subtract(billSec);
-            Console.WriteLine(span.TotalSeconds);
-            Console.WriteLine("Birthday:        " + bd);
-            Console.WriteLine("Billion Seconds: " + billSec);
-
-            Console.WriteLine("Days left: " + billSec.Subtract(DateTime.Now).TotalDays);
-            Console.WriteLine("Hours left: " + billSec.Subtract(DateTime.Now).TotalHours);
-            Console.WriteLine("Minutes left: " + billSec.Subtract(DateTime.Now).TotalMinutes);
-
-
-
-            var temp = new List<string> { "Hi", "There" };
-
-            foreach(var word in temp)
+            Console.WriteLine();
+            Console.WriteLine($"Birthday:        {birthDate:d}");
+            Console.WriteLine("You are:");
+            Console.WriteLine($"  {age.TotalSeconds:N0} seconds old");
+            Console.WriteLine($"  {age.TotalMinutes:N0} minutes old");
+            Console.WriteLine($"  {age.TotalHours:N0} hours old");
+            Console.WriteLine($"  {age.TotalDays:N0} days old");
+            Console.WriteLine($"  {age.TotalDays / 7:N0} weeks old");
+            int monthsOld = (now.Year - birthDate.Year) * 12 + now.Month - birthDate.Month;
+            if (now.Day < birthDate.Day)
             {
-                Console.WriteLine(word);
+                monthsOld--;
             }
-            
+            Console.WriteLine($"  {monthsOld} months old");
+            Console.WriteLine($"  {age.TotalDays / 365.25:F2} years old");
+            Console.WriteLine($"  {age.TotalDays / 365.25 * 7:F2} dog years old");
+            const int beatsPerMinute = 75;
+            Console.WriteLine($"  {age.TotalMinutes * beatsPerMinute:N0} heartbeats (at {beatsPerMinute} bpm)");
 
+            const double billionSeconds = 1000000000d;
+            DateTime billSec = birthDate.AddSeconds(billionSeconds);
+            TimeSpan untilBill = billSec - now;
+            Console.WriteLine();
+            Console.WriteLine("Billion Seconds: " + billSec);
+            if (untilBill.TotalSeconds > 0)
+            {
+                Console.WriteLine("Time until 1 billion seconds:");
+                DisplayCountdown(billSec);
+            }
+            else
+            {
+                Console.WriteLine($"You passed the billion second mark {FormatSpan(-untilBill)} ago!");
+            }
 
+            const int lifeExpectancyYears = 79;
+            DateTime expectedEnd = birthDate.AddYears(lifeExpectancyYears);
+            TimeSpan lifeLeft = expectedEnd - now;
+            Console.WriteLine();
+            Console.WriteLine($"Estimated end of life ({lifeExpectancyYears} yrs): {expectedEnd:d}");
+            if (lifeLeft.TotalSeconds > 0)
+            {
+                Console.WriteLine($"Years left: {lifeLeft.TotalDays / 365.25:F1}");
+                Console.WriteLine($"Months left: {lifeLeft.TotalDays / 30.4375:N0}");
+                Console.WriteLine($"Weeks left: {lifeLeft.TotalDays / 7:N0}");
+                Console.WriteLine($"Days left: {lifeLeft.TotalDays:N0}");
+            }
+            else
+            {
+                Console.WriteLine("You've already outlived the average life expectancy!");
+            }
+            Console.WriteLine($"You have lived {age.TotalDays / (lifeExpectancyYears * 365.25):P2} of your expected lifespan.");
 
-
-
+            Console.WriteLine();
+            Console.WriteLine("Press Enter to exit.");
             Console.ReadLine();
-
-           /* while (true) {
-                Console.Clear();
-                Console.WriteLine(countDown());
-                Console.WriteLine(DateTime.Now.ToString("h:mmtt d/MM/yyyy"));
-                Console.ReadLine(); 
-             }*/
-
         }
 
-        public static double countDown()
+        static DateTime ReadBirthDate()
         {
-            // TimeSpan span = DateTime.Now.Subtract(new DateTime(2020, 1, 1, 0, 0, 0));
-            // return span.TotalSeconds;
-            return 0.0;
+            while (true)
+            {
+                Console.WriteLine("Enter your birthdate (YYYY-MM-DD):");
+                if (DateTime.TryParse(Console.ReadLine(), out DateTime birthDate))
+                {
+                    return birthDate.Date;
+                }
+                Console.WriteLine("Invalid date. Please try again.");
+            }
         }
 
+        public static string FormatSpan(TimeSpan span)
+        {
+            span = span.Duration();
+            return $"{span.Days} days, {span.Hours} hours, {span.Minutes} minutes, {span.Seconds} seconds";
+        }
+
+        static void DisplayCountdown(DateTime target)
+        {
+            const int maxUpdates = 5;
+            for (int i = 0; i < maxUpdates; i++)
+            {
+                TimeSpan remaining = target - DateTime.Now;
+                if (remaining.TotalSeconds <= 0)
+                {
+                    Console.WriteLine("Reached 1 billion seconds!");
+                    return;
+                }
+                Console.Write("\r" + FormatSpan(remaining) + " remaining   ");
+                Thread.Sleep(1000);
+            }
+            Console.WriteLine();
+        }
     }
 }
+


### PR DESCRIPTION
## Summary
- parse birth date with validation and compute additional lifespan metrics
- add dog-year & heartbeat estimates plus months remaining in life expectancy
- show countdown to the billion-second milestone and message if it's already passed

## Testing
- `mcs Program.cs && mono Program.exe <<EOF
1988-06-24
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68aba8f302bc8323a904e75d4474c6c6